### PR TITLE
Adding the right export features when one authored formulas in LO with the extension TexMaths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+DIR = $(shell basename $$(pwd))
+
+all:
+
+zip:
+	cd .. ; zip -r /tmp/monextension.zip $(DIR) --exclude $(DIR)/.git/\*
+	@echo  ZIP dans /tmp/monextension.zip

--- a/odt2dw.xsl
+++ b/odt2dw.xsl
@@ -348,6 +348,7 @@ Source :
     <!--<xsl:text disable-output-escaping="yes" >{{</xsl:text>
     <xsl:value-of select="substring-after(@xlink:href,'/')"/>
     <xsl:text disable-output-escaping="yes" >}}</xsl:text>-->
+    GRRR
   </xsl:template>
 
   <!-- Mise en forme des balises span et p

--- a/odt2dw.xsl
+++ b/odt2dw.xsl
@@ -347,7 +347,8 @@ Source :
   <xsl:template match="//draw:image">
     <!--<xsl:text disable-output-escaping="yes" >{{</xsl:text>
     <xsl:value-of select="substring-after(@xlink:href,'/')"/>
-    <xsl:text disable-output-escaping="yes" >}}GRRR</xsl:text>-->
+    GRRR
+    <xsl:text disable-output-escaping="yes" >}}</xsl:text>-->
   </xsl:template>
 
   <!-- Mise en forme des balises span et p

--- a/odt2dw.xsl
+++ b/odt2dw.xsl
@@ -331,6 +331,66 @@ Source :
     </xsl:choose>
   </xsl:template>
 
+  <xsl:template name="neme-split">
+    <!-- Georges Khaznadar <georgesk@debian.org>, 2022-06-05
+
+	 renvoie la nième chaine, après séparation par le séparateur 
+
+	 paramètres :
+	 ------------
+	 string : une chaîne
+	 n :      un index, 0 par défaut
+	 sep :    un séparateur, "§" par défaut
+	 depth:   la profondeur d'appel récursif, 0 par défaut
+    -->
+    <xsl:param name="string"/>
+    <xsl:param name="n" select="0"/>
+    <xsl:param name="sep" select="'§'"/>
+    <xsl:param name="depth" select="0"/>
+    <xsl:choose>
+      <xsl:when test="not (contains($string, $sep))">
+	<xsl:value-of select="$string"/>
+      </xsl:when>
+      <xsl:otherwise>
+	<xsl:variable name="prefix" select="substring-before($string, $sep)"/>
+	<xsl:variable name="suffix" select="substring-after($string, $sep)"/>
+	<xsl:choose>
+	  <xsl:when test="$n = $depth">
+	    <xsl:value-of select="$prefix"/>
+	  </xsl:when>
+	  <xsl:otherwise>
+	    <xsl:call-template name="neme-split">
+	      <xsl:with-param name="string" select="$suffix"/>
+	      <xsl:with-param name="n" select="$n"/>
+	      <xsl:with-param name="sep" select="$sep"/>
+	      <xsl:with-param name="depth" select="($depth+1)"/>
+	    </xsl:call-template>
+	  </xsl:otherwise>
+	</xsl:choose>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="texmaths" match="//draw:g">
+    <!-- Georges Khaznadar <georgesk@debian.org>, 2022-06-05
+
+	 traite les formules entrées par le plugin TexMaths de LibreOffice
+	 pour que MathJax puisse les afficher proprement
+    -->
+    <xsl:variable name="title" select="svg:title"/>
+    <xsl:if test="$title = 'TexMaths'">
+      <xsl:text disable-output-escaping="yes">$</xsl:text>
+      <!-- troisième élément de svg:desc après séparation par les "§" -->
+      <xsl:call-template name="neme-split">
+	<xsl:with-param name="string" select="svg:desc"/>
+	<xsl:with-param name="n" select="2"/>
+	<xsl:with-param name="sep" select="'§'"/>
+      </xsl:call-template>
+      <xsl:text disable-output-escaping="yes">$</xsl:text>
+
+    </xsl:if>
+  </xsl:template>
+
   <xsl:template match="//draw:frame">
     <xsl:param name="cmtopx" value="37.795275591"/>
     <xsl:text disable-output-escaping="yes" >{{</xsl:text>
@@ -348,7 +408,6 @@ Source :
     <!--<xsl:text disable-output-escaping="yes" >{{</xsl:text>
     <xsl:value-of select="substring-after(@xlink:href,'/')"/>
     <xsl:text disable-output-escaping="yes" >}}</xsl:text>-->
-    GRRR
   </xsl:template>
 
   <!-- Mise en forme des balises span et p

--- a/odt2dw.xsl
+++ b/odt2dw.xsl
@@ -337,7 +337,7 @@ Source :
 	 renvoie la nième chaine, après séparation par le séparateur 
 
 	 paramètres :
-	 ------------
+	 ===========
 	 string : une chaîne
 	 n :      un index, 0 par défaut
 	 sep :    un séparateur, "§" par défaut

--- a/odt2dw.xsl
+++ b/odt2dw.xsl
@@ -347,7 +347,7 @@ Source :
   <xsl:template match="//draw:image">
     <!--<xsl:text disable-output-escaping="yes" >{{</xsl:text>
     <xsl:value-of select="substring-after(@xlink:href,'/')"/>
-    <xsl:text disable-output-escaping="yes" >}}</xsl:text>-->
+    <xsl:text disable-output-escaping="yes" >}}GRRR</xsl:text>-->
   </xsl:template>
 
   <!-- Mise en forme des balises span et p

--- a/odt2dw.xsl
+++ b/odt2dw.xsl
@@ -347,7 +347,6 @@ Source :
   <xsl:template match="//draw:image">
     <!--<xsl:text disable-output-escaping="yes" >{{</xsl:text>
     <xsl:value-of select="substring-after(@xlink:href,'/')"/>
-    GRRR
     <xsl:text disable-output-escaping="yes" >}}</xsl:text>-->
   </xsl:template>
 

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,5 +1,5 @@
 base   odtplus2dw
-author Jose Torrecilla
+author Jose Torrecilla, contributor Georges Khaznadar
 email  qky669@gmail.com
 date   2018-10-27
 name   odtplus2dw plugin

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   odtplus2dw
 author Jose Torrecilla, contributor Georges Khaznadar
 email  qky669@gmail.com
-date   2018-10-27
+date   2022-06-05
 name   odtplus2dw plugin
 desc   Create a dokuwiki page from a file
 url    http://www.dokuwiki.org/plugin:odtplus2dw


### PR DESCRIPTION
Hello,
some change in the xsl file improve the exported data when somebody authors formulas in the ODT document
with TexMath (https://extensions.libreoffice.org/en/extensions/show/texmaths-1).

Before the change: *nothing* is exported from the formula
After the change: the LaTeX source of the formula is exported, correctly surrounded by "$" signs, so MathJax can render it properly.

Example : when the ODT document contains a formula "a squared times pi", one can see a nice SVG rendered formula on the screen; when this is exported to DokuWiki, it yields:
$a^2 \times \pi$ (as Github features Mathjax, I must write it again so you can see the source: <span>$</span>a^2 \times \pi<span>$</span>)

Thank you in advance for considering this contribution.

Best regards,                        Georges.